### PR TITLE
Corrigir empresa vencedora na emissão de ATA

### DIFF
--- a/lib/pdf/bidding/minute/base.rb
+++ b/lib/pdf/bidding/minute/base.rb
@@ -92,7 +92,7 @@ module Pdf::Bidding
     end
 
     def proposals_sentence(proposals)
-      proposals.all_lower.inject([]) do |array, proposal|
+      proposals.active_and_orderly.inject([]) do |array, proposal|
         array << proposal_line(proposal)
       end.to_sentence
     end

--- a/lib/pdf/builder/base.rb
+++ b/lib/pdf/builder/base.rb
@@ -44,6 +44,10 @@ module Pdf::Builder
     def header_center
       "#{wrap(cooperative.name)}\n"\
       "#{cooperative.cnpj}\n"\
+      "#{wrap(cooperative_address)}"
+    end
+
+    def cooperative_address
       "#{cooperative.address.address}, "\
       "#{cooperative.address.city.name} - "\
       "#{cooperative.address.city.state.name}"

--- a/spec/lib/pdf/bidding/minute/finnished_html_spec.rb
+++ b/spec/lib/pdf/bidding/minute/finnished_html_spec.rb
@@ -118,6 +118,20 @@ RSpec.describe Pdf::Bidding::Minute::FinnishedHtml do
         it { is_expected.not_to include("@@") }
       end
 
+      context 'when threre are draft proposals' do
+        let(:file_type) { 'minute_finnished_global' }
+        let(:service_build) { described_class.new(params) }
+
+        before do
+          allow(service_build).to receive(:proposal_line).and_return('')
+          proposal_1.draft!
+          proposal_2.draft!
+          service_build.call
+        end
+
+        it { expect(service_build).not_to have_received(:proposal_line) }
+      end
+
       after do
         File.write(
           Rails.root.join("spec/fixtures/myfiles/#{file_type}_template.html"),


### PR DESCRIPTION
ISSUE: https://github.com/SolucaoOnlineDeLicitacao/sol-api/issues/6

---

Também foi adicionado a quebra de linha para textos extensos no cabeçalho dos arquivos .pdf