### PR TITLE
Criação de Migration para aumentar o tamanho do `items.code` de int para bigint

### DIFF
--- a/db/migrate/20190919140224_change_code_type_from_items.rb
+++ b/db/migrate/20190919140224_change_code_type_from_items.rb
@@ -1,0 +1,5 @@
+class ChangeCodeTypeFromItems < ActiveRecord::Migration[5.2]
+  def change
+    change_column :items, :code, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_04_115558) do
+ActiveRecord::Schema.define(version: 2019_09_19_140224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_115558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "classification_id"
-    t.integer "code"
+    t.bigint "code"
     t.integer "unit_id"
     t.index ["classification_id"], name: "index_items_on_classification_id"
     t.index ["owner_type", "owner_id"], name: "index_items_on_owner_type_and_owner_id"


### PR DESCRIPTION
**IMPORTANTE: Garantir a realização de um backup do banco de dados antes de realizar o deploy.**

Exemplo de backup (caso precise):
```
pg_dump <database do database.yml> -h <host do database.yml> -U <username do database.yml> > <nome do arquivo>.sql
```

Ao realizar o deploy em produção da API, na etapa em que o comando `rake db:migrate` é executado, a Migration será aplicada no banco de dados.

---

Mais informações de como criar Migrations podem ser encontradas no link https://edgeguides.rubyonrails.org/active_record_migrations.html