### PR TITLE
Melhoria para os serviços de mudança de situação de licitações

### DIFF
--- a/app/models/bidding.rb
+++ b/app/models/bidding.rb
@@ -98,9 +98,9 @@ class Bidding < ApplicationRecord
     joins(:cooperative).where(cooperatives: { id: cooperative_id })
   end
   scope :not_draft, -> { where.not(status: :draft) }
-  scope :approved_and_started_today, -> { approved.where(start_date: Date.current) }
-  scope :drawed_today, -> { draw.where(draw_at: Date.current) }
-  scope :ongoing_and_closed_today, -> { ongoing.where(closing_date: Date.current) }
+  scope :approved_and_started_until_today, -> { approved.where("start_date <= :date", date: Date.current) }
+  scope :drawed_until_today, -> { draw.where("draw_at <= :date", date: Date.current) }
+  scope :ongoing_and_closed_until_today, -> { ongoing.where("closing_date <= :date", date: Date.current) }
   scope :in_progress, -> { where.not(status: [:draw, :canceled, :failure]) }
 
   delegate :name, to: :classification, prefix: true, allow_nil: true

--- a/app/services/biddings_service/approved_to_ongoing.rb
+++ b/app/services/biddings_service/approved_to_ongoing.rb
@@ -11,7 +11,7 @@ module BiddingsService
 
     def approved_biddings_to_ongoing
       execute_or_rollback do
-        Bidding.approved_and_started_today.each do |bidding|
+        Bidding.approved_and_started_until_today.each do |bidding|
           BiddingsService::Ongoing.call!(bidding: bidding)
         end
       end

--- a/app/services/biddings_service/draw_to_under_review.rb
+++ b/app/services/biddings_service/draw_to_under_review.rb
@@ -11,7 +11,7 @@ module BiddingsService
 
     def drawed_biddings_to_under_review
       execute_or_rollback do
-        Bidding.drawed_today.each do |bidding|
+        Bidding.drawed_until_today.each do |bidding|
           BiddingsService::UnderReview.call!(bidding: bidding)
         end
       end

--- a/app/services/biddings_service/ongoing_to_under_review.rb
+++ b/app/services/biddings_service/ongoing_to_under_review.rb
@@ -11,7 +11,7 @@ module BiddingsService
 
     def ongoing_biddings_to_under_review
       execute_or_rollback do
-        Bidding.ongoing_and_closed_today.each do |bidding|
+        Bidding.ongoing_and_closed_until_today.each do |bidding|
           BiddingsService::UnderReview.call!(bidding: bidding)
         end
       end

--- a/spec/models/bidding_spec.rb
+++ b/spec/models/bidding_spec.rb
@@ -446,38 +446,38 @@ RSpec.describe Bidding, type: :model do
       it { expect(Bidding.not_draft).to match_array expected_biddings }
     end
 
-    describe '.approved_and_started_today' do
+    describe '.approved_and_started_until_today' do
       let!(:bidding1) { create(:bidding, status: :approved, start_date: Date.current) }
-      let!(:bidding2) { create(:bidding, status: :approved, start_date: Date.current) }
-      let!(:bidding3) { create(:bidding, status: :approved) }
+      let!(:bidding2) { create(:bidding, status: :approved, start_date: Date.current-1.day) }
+      let!(:bidding3) { create(:bidding, status: :approved, start_date: Date.tomorrow) }
       let!(:bidding4) { create(:bidding, status: :canceled) }
       let!(:bidding5) { create(:bidding, status: :under_review) }
 
-      it { expect(Bidding.approved_and_started_today).to match_array [bidding1, bidding2] }
+      it { expect(Bidding.approved_and_started_until_today).to match_array [bidding1, bidding2] }
     end
 
-    describe '.drawed_today' do
-      let!(:bidding1) { create(:bidding, status: :waiting) }
-      let!(:bidding2) { create(:bidding, status: :approved) }
-      let!(:bidding3) { create(:bidding, status: :draw, closing_date: Date.tomorrow, draw_end_days: 1) }
-      let!(:bidding4) { create(:bidding, status: :draw) }
-      let!(:bidding5) { create(:bidding, status: :draw, closing_date: Date.tomorrow, draw_end_days: 1) }
+    describe '.drawed_until_today' do
+      let!(:bidding1) { create(:bidding, status: :draw, closing_date: Date.tomorrow, draw_end_days: 1) }
+      let!(:bidding2) { create(:bidding, status: :draw, closing_date: Date.today, draw_end_days: 1) }
+      let!(:bidding3) { create(:bidding, status: :draw, closing_date: Date.tomorrow+2.days, draw_end_days: 1) }
+      let!(:bidding4) { create(:bidding, status: :waiting) }
+      let!(:bidding5) { create(:bidding, status: :approved) }
 
-      let(:date_current) { bidding3.closing_date + bidding3.draw_end_days.to_i }
+      let(:date_current) { bidding1.closing_date + bidding1.draw_end_days.to_i }
 
       before { allow(Date).to receive(:current).and_return date_current }
 
-      it { expect(Bidding.drawed_today).to match_array [bidding3, bidding5] }
+      it { expect(Bidding.drawed_until_today).to match_array [bidding1, bidding2] }
     end
 
-    describe '.ongoing_and_closed_today' do
-      let!(:bidding1) { create(:bidding, status: :waiting) }
-      let!(:bidding2) { create(:bidding, status: :approved) }
-      let!(:bidding3) { create(:bidding, status: :ongoing, closing_date: Date.current) }
-      let!(:bidding4) { create(:bidding, status: :ongoing) }
-      let!(:bidding5) { create(:bidding, status: :ongoing, closing_date: Date.current) }
+    describe '.ongoing_and_closed_until_today' do
+      let!(:bidding1) { create(:bidding, status: :ongoing, closing_date: Date.current-1.day) }
+      let!(:bidding2) { create(:bidding, status: :ongoing, closing_date: Date.current) }
+      let!(:bidding3) { create(:bidding, status: :ongoing, closing_date: Date.tomorrow) }
+      let!(:bidding4) { create(:bidding, status: :waiting) }
+      let!(:bidding5) { create(:bidding, status: :approved) }
 
-      it { expect(Bidding.ongoing_and_closed_today).to match_array [bidding3, bidding5] }
+      it { expect(Bidding.ongoing_and_closed_until_today).to match_array [bidding2, bidding1] }
     end
 
     describe 'in_progress' do

--- a/spec/services/biddings_service/approved_to_ongoing_spec.rb
+++ b/spec/services/biddings_service/approved_to_ongoing_spec.rb
@@ -1,60 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe BiddingsService::ApprovedToOngoing, type: :service do
-  let!(:not_eligible_bidding_1) { create(:bidding, status: :approved) }
-  let!(:not_eligible_bidding_2) { create(:bidding, status: :canceled) }
-  let!(:not_eligible_bidding_3) { create(:bidding, status: :under_review) }
-  let(:status_update_service) { BiddingsService::Ongoing }
-
   describe '.call' do
-    context 'when have approved biddings' do
-      let!(:eligible_bidding_1) do
-        create(:bidding, status: :approved, start_date: Date.current)
-      end
-      let!(:eligible_bidding_2) do
-        create(:bidding, status: :approved, start_date: Date.current)
-      end
-
-      before do
-        allow(status_update_service).
-          to receive(:call!).with(bidding: eligible_bidding_1).and_return(true)
-        allow(status_update_service).
-          to receive(:call!).with(bidding: eligible_bidding_2).and_return(true)
-
-        described_class.call
-      end
-
-      it { is_expected.to be_truthy }
-      it do
-        expect(status_update_service).
-          to have_received(:call!).with(bidding: eligible_bidding_1)
-      end
-      it do
-        expect(status_update_service).
-          to have_received(:call!).with(bidding: eligible_bidding_2)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_1)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_2)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_3)
-      end
+    let!(:eligible_bidding_1) do
+      create(:bidding, status: :approved, start_date: Date.current)
     end
 
-    context 'when have not approved biddings' do
-      before do
-        allow(status_update_service).to receive(:call!).and_call_original
-
-        described_class.call
-      end
-
-      it { expect(status_update_service).not_to have_received(:call!) }
+    let!(:eligible_bidding_2) do
+      create(:bidding, status: :approved, start_date: Date.current)
     end
+
+    let!(:not_eligible_bidding_1) { create(:bidding, status: :ongoing) }
+
+    before do
+      allow(Bidding).to receive(:approved_and_started_until_today) { [eligible_bidding_1, eligible_bidding_2] }
+      allow(BiddingsService::Ongoing).to receive(:call!).with(bidding: eligible_bidding_1)
+      allow(BiddingsService::Ongoing).to receive(:call!).with(bidding: eligible_bidding_2)
+
+      described_class.call
+    end
+
+    it { expect(BiddingsService::Ongoing).to have_received(:call!).with(bidding: eligible_bidding_1) }
+    it { expect(BiddingsService::Ongoing).to have_received(:call!).with(bidding: eligible_bidding_2) }
   end
 end

--- a/spec/services/biddings_service/draw_to_under_review_spec.rb
+++ b/spec/services/biddings_service/draw_to_under_review_spec.rb
@@ -1,64 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe BiddingsService::DrawToUnderReview, type: :service do
-  let!(:not_eligible_bidding_1) { create(:bidding, status: :waiting) }
-  let!(:not_eligible_bidding_2) { create(:bidding, status: :approved) }
-  let!(:not_eligible_bidding_3) { create(:bidding, status: :draw) }
-  let(:status_update_service) { BiddingsService::UnderReview }
-
-  before { Bidding.skip_callback(:validation, :before, :update_draw_at) }
-
-  after { Bidding.set_callback(:validation, :before, :update_draw_at) }
-
   describe '.call' do
-    context 'when have draw biddings' do
-      let!(:eligible_bidding_1) do
-        create(:bidding, status: :draw, draw_at: Date.current)
-      end
-      let!(:eligible_bidding_2) do
-        create(:bidding, status: :draw, draw_at: Date.current)
-      end
-
-      before do
-        allow(status_update_service).
-          to receive(:call!).with(bidding: eligible_bidding_1).and_return(true)
-        allow(status_update_service).
-          to receive(:call!).with(bidding: eligible_bidding_2).and_return(true)
-
-        described_class.call
-      end
-
-      it { is_expected.to be_truthy }
-      it do
-        expect(status_update_service).
-          to have_received(:call!).with(bidding: eligible_bidding_1)
-      end
-      it do
-        expect(status_update_service).
-          to have_received(:call!).with(bidding: eligible_bidding_2)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_1)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_2)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_3)
-      end
+    let!(:eligible_bidding_1) do
+      create(:bidding, status: :draw, draw_at: Date.current)
     end
 
-    context 'when have not draw biddings' do
-      before do
-        allow(status_update_service).to receive(:call!).and_call_original
-
-        described_class.call
-      end
-
-      it { expect(status_update_service).not_to have_received(:call!) }
+    let!(:eligible_bidding_2) do
+      create(:bidding, status: :draw, draw_at: Date.current)
     end
+
+    let!(:not_eligible_bidding_1) { create(:bidding, status: :waiting) }
+
+    before do
+      allow(Bidding).to receive(:drawed_until_today) { [eligible_bidding_1, eligible_bidding_2] }
+      allow(BiddingsService::UnderReview).to receive(:call!).with(bidding: eligible_bidding_1)
+      allow(BiddingsService::UnderReview).to receive(:call!).with(bidding: eligible_bidding_2)
+
+      described_class.call
+    end
+
+    it { expect(BiddingsService::UnderReview).to have_received(:call!).with(bidding: eligible_bidding_1) }
+    it { expect(BiddingsService::UnderReview).to have_received(:call!).with(bidding: eligible_bidding_2) }
   end
 end

--- a/spec/services/biddings_service/ongoing_to_under_review_spec.rb
+++ b/spec/services/biddings_service/ongoing_to_under_review_spec.rb
@@ -1,60 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe BiddingsService::OngoingToUnderReview, type: :service do
-  let!(:not_eligible_bidding_1) { create(:bidding, status: :waiting) }
-  let!(:not_eligible_bidding_2) { create(:bidding, status: :approved) }
-  let!(:not_eligible_bidding_3) { create(:bidding, status: :ongoing) }
-  let(:status_update_service) { BiddingsService::UnderReview }
-
   describe '.call' do
-    context 'when have ongoing biddings' do
-      let!(:eligible_bidding_1) do
-        create(:bidding, status: :ongoing, closing_date: Date.current)
-      end
-      let!(:eligible_bidding_2) do
-        create(:bidding, status: :ongoing, closing_date: Date.current)
-      end
-
-      before do
-        allow(status_update_service).
-          to receive(:call!).with(bidding: eligible_bidding_1).and_return(true)
-        allow(status_update_service).
-          to receive(:call!).with(bidding: eligible_bidding_2).and_return(true)
-
-        described_class.call
-      end
-
-      it { is_expected.to be_truthy }
-      it do
-        expect(status_update_service).
-          to have_received(:call!).with(bidding: eligible_bidding_1)
-      end
-      it do
-        expect(status_update_service).
-          to have_received(:call!).with(bidding: eligible_bidding_2)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_1)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_2)
-      end
-      it do
-        expect(status_update_service).
-          not_to have_received(:call!).with(bidding: not_eligible_bidding_3)
-      end
+    let!(:eligible_bidding_1) do
+      create(:bidding, status: :ongoing, closing_date: Date.current)
     end
 
-    context 'when have not ongoing biddings' do
-      before do
-        allow(status_update_service).to receive(:call!).and_call_original
-
-        described_class.call
-      end
-
-      it { expect(status_update_service).not_to have_received(:call!) }
+    let!(:eligible_bidding_2) do
+      create(:bidding, status: :ongoing, closing_date: Date.current)
     end
+
+    let!(:not_eligible_bidding_1) { create(:bidding, status: :waiting) }
+
+    before do
+      allow(Bidding).to receive(:ongoing_and_closed_until_today) { [eligible_bidding_1, eligible_bidding_2] }
+      allow(BiddingsService::UnderReview).to receive(:call!).with(bidding: eligible_bidding_1)
+      allow(BiddingsService::UnderReview).to receive(:call!).with(bidding: eligible_bidding_2)
+
+      described_class.call
+    end
+
+    it { expect(BiddingsService::UnderReview).to have_received(:call!).with(bidding: eligible_bidding_1) }
+    it { expect(BiddingsService::UnderReview).to have_received(:call!).with(bidding: eligible_bidding_2) }
   end
 end


### PR DESCRIPTION
Escopos de licitação atualizados:

- "Liberada" para "Aberta";
- "Aberta" para "Em revisão";
- "Empatada" para "Em revisão".

Todos os escopos agora levam em consideração licitações com datas até o dia atual ao invés de apenas o dia atual (de `=` para `<=`).

---

- Serviços atualizados com chamada para novos escopos e testes refatorados para testar apenas a chamada e não a lógica do escopo.