### PR TITLE
Aplicar escopo de listagem de licitação convite fechado em dashboard #27

### DIFF
--- a/app/controllers/supp/biddings_controller.rb
+++ b/app/controllers/supp/biddings_controller.rb
@@ -26,7 +26,7 @@ module Supp
     end
 
     def find_biddings
-      Bidding.by_provider(current_provider).accessible_by(current_ability)
+      Bidding.by_provider(current_provider).accessible_by(current_ability).distinct('biddings.id')
     end
   end
 end

--- a/app/controllers/supp/dashboards_controller.rb
+++ b/app/controllers/supp/dashboards_controller.rb
@@ -15,7 +15,7 @@ module Supp
     end
 
     def find_biddings
-      Bidding.active.sorted
+      Bidding.by_provider(current_provider).accessible_by(current_ability).sorted.distinct('biddings.id')
     end
   end
 end

--- a/spec/controllers/supp/biddings_controller_spec.rb
+++ b/spec/controllers/supp/biddings_controller_spec.rb
@@ -54,14 +54,22 @@ RSpec.describe Supp::BiddingsController, type: :controller do
       end
 
       describe 'exposes' do
+        let(:stub_biddings) { Bidding.all }
+        let(:current_ability) { Abilities::SupplierAbility.new(user) }
+
         before do
-          allow(Bidding).to receive(:by_provider).with(provider) { Bidding.all }
+          allow(controller).to receive(:current_ability) { current_ability }
+  
+          allow(Bidding).to receive(:by_provider).with(provider) { stub_biddings }
+          allow(stub_biddings).to receive(:accessible_by).with(current_ability) { stub_biddings }
+          allow(stub_biddings).to receive(:distinct).with('biddings.id') { Bidding.all }
 
           get_index
         end
 
         it { expect(Bidding).to have_received(:by_provider).with(provider) }
-        it { expect(controller.biddings).to match_array biddings }
+        it { expect(stub_biddings).to have_received(:accessible_by).with(current_ability) }
+        it { expect(stub_biddings).to have_received(:distinct).with('biddings.id') }
       end
 
       describe 'JSON' do

--- a/spec/controllers/supp/dashboards_controller_spec.rb
+++ b/spec/controllers/supp/dashboards_controller_spec.rb
@@ -18,16 +18,41 @@ RSpec.describe Supp::DashboardsController, type: :controller do
     let(:params) { {} }
 
     subject(:get_show) { get :show, params: params, xhr: true }
+    
+    describe '#initialize' do
+      before do
+        allow(controller).to receive(:biddings) { biddings }
+        allow(::Dashboards::Supplier).to receive(:new).with(biddings: biddings)
 
-    before do
-      allow(::Dashboards::Supplier).to receive(:new).with(biddings: Bidding.active.sorted)
-      get_show
+        get_show
+      end
+
+      it { expect(::Dashboards::Supplier).to have_received(:new).with(biddings: biddings) }
     end
-
-    it { expect(::Dashboards::Supplier).to have_received(:new).with(biddings: Bidding.active.sorted) }
 
     describe 'http_status' do
       it { expect(response).to have_http_status :ok }
+    end
+
+    describe 'exposes' do
+      let(:stub_biddings) { Bidding.all }
+      let(:current_ability) { Abilities::SupplierAbility.new(user) }
+
+      before do
+        allow(controller).to receive(:current_ability) { current_ability }
+
+        allow(Bidding).to receive(:by_provider).with(provider) { stub_biddings }
+        allow(stub_biddings).to receive(:accessible_by).with(current_ability) { stub_biddings }
+        allow(stub_biddings).to receive(:sorted) { stub_biddings }
+        allow(stub_biddings).to receive(:distinct).with('biddings.id') { Bidding.all }
+
+        get_show
+      end
+
+      it { expect(Bidding).to have_received(:by_provider).with(provider) }
+      it { expect(stub_biddings).to have_received(:accessible_by).with(current_ability) }
+      it { expect(stub_biddings).to have_received(:sorted) }
+      it { expect(stub_biddings).to have_received(:distinct).with('biddings.id') }
     end
   end
 end


### PR DESCRIPTION
Atualizado escopo de listagem de últimas licitações do dashboard do fornecedor para não listar licitações do tipo convite fechado (sem convite). 

Este é o escopo padrão da listagem de licitações ("Procurar licitações" ou "Menu > Licitações").