### PR TITLE
Ajuste de unicidade para criação de propostas

### DIFF
--- a/app/models/lot_proposal.rb
+++ b/app/models/lot_proposal.rb
@@ -22,6 +22,8 @@ class LotProposal < ApplicationRecord
             :supplier,
             presence: true
 
+  validates :lot_id, uniqueness: { scope: :supplier_id }
+
   validates :delivery_price, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   validate :validate_price_total

--- a/db/migrate/20191119141502_add_index_to_lot_proposals.rb
+++ b/db/migrate/20191119141502_add_index_to_lot_proposals.rb
@@ -1,0 +1,5 @@
+class AddIndexToLotProposals < ActiveRecord::Migration[5.2]
+  def change
+		add_index(:lot_proposals, [:lot_id, :supplier_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_19_140224) do
+ActiveRecord::Schema.define(version: 2019_11_19_141502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -319,6 +319,7 @@ ActiveRecord::Schema.define(version: 2019_09_19_140224) do
     t.bigint "supplier_id"
     t.decimal "delivery_price"
     t.bigint "parent_id"
+    t.index ["lot_id", "supplier_id"], name: "index_lot_proposals_on_lot_id_and_supplier_id", unique: true
     t.index ["lot_id"], name: "index_lot_proposals_on_lot_id"
     t.index ["proposal_id"], name: "index_lot_proposals_on_proposal_id"
     t.index ["supplier_id"], name: "index_lot_proposals_on_supplier_id"

--- a/lib/transaction_methods.rb
+++ b/lib/transaction_methods.rb
@@ -2,6 +2,7 @@ module TransactionMethods
   EXCEPTIONS = [
     ActiveRecord::RecordInvalid,
     ActiveRecord::RecordNotDestroyed,
+    ActiveRecord::RecordNotUnique,
     BlockchainError,
     RecalculateItemError,
     ArgumentError,

--- a/spec/lib/transaction_methods_spec.rb
+++ b/spec/lib/transaction_methods_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe TransactionMethods do
         it { is_expected.to be_falsey }
       end
 
+      context 'and raises ActiveRecord::RecordNotUnique error' do
+        before { expect(record). to receive(:save).and_raise(ActiveRecord::RecordNotUnique) }
+
+        it { is_expected.to be_falsey }
+      end
+
       context 'and raises BlockchainError error' do
         before { expect(record). to receive(:save).and_raise(BlockchainError) }
 
@@ -37,6 +43,18 @@ RSpec.describe TransactionMethods do
 
       context 'and raises RecalculateItemError error' do
         before { expect(record). to receive(:save).and_raise(RecalculateItemError) }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'and raises ArgumentError error' do
+        before { expect(record). to receive(:save).and_raise(ArgumentError) }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context 'and raises CreateContractError error' do
+        before { expect(record). to receive(:save).and_raise(CreateContractError) }
 
         it { is_expected.to be_falsey }
       end

--- a/spec/models/lot_proposal_spec.rb
+++ b/spec/models/lot_proposal_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe LotProposal, type: :model do
     it { is_expected.to validate_presence_of :lot }
     it { is_expected.to validate_presence_of :proposal }
     it { is_expected.to validate_presence_of :supplier }
+    
+    context 'uniqueness' do
+      before { build(:lot_proposal) }
+
+      it { is_expected.to validate_uniqueness_of(:lot_id).scoped_to(:supplier_id) }
+    end
 
     describe 'delivery_price' do
       let(:lot_proposal) { create(:lot_proposal, delivery_price: 10) }

--- a/spec/support/shared_examples/services/concerns/contract_classification.rb
+++ b/spec/support/shared_examples/services/concerns/contract_classification.rb
@@ -4,7 +4,10 @@ RSpec.shared_examples 'services/concerns/contract_classification' do
 
   let!(:providers) { create_list(:provider, 2, :skip_validation, skip_classification: true) }
   let!(:provider) { providers.first }
+  let!(:provider_2) { providers.last }
+
   let!(:supplier) { create(:supplier, provider: provider) }
+  let!(:supplier_2) { create(:supplier, provider: provider_2) }
 
   let!(:item_1) { create(:item, classification: classification_1) }
   let!(:item_2) { create(:item, classification: classification_2) }
@@ -117,14 +120,14 @@ RSpec.shared_examples 'services/concerns/contract_classification' do
 
   let!(:proposal_5) do
     proposal = create(:proposal, build_lot_proposal: false, bidding: bidding_4,
-        provider: provider)
+        provider: provider_2)
     proposal.update_column(:price_total, 4)
     proposal
   end
 
   let!(:proposal_6) do
     proposal = create(:proposal, build_lot_proposal: false, bidding: bidding_3,
-        provider: provider)
+        provider: provider_2)
     proposal.update_column(:price_total, 3)
     proposal
   end
@@ -151,12 +154,12 @@ RSpec.shared_examples 'services/concerns/contract_classification' do
 
   let!(:lot_proposal_5) do
     create(:lot_proposal, build_lot_group_item_lot_proposal: false,
-        lot: lot_4, proposal: proposal_5, supplier: supplier)
+        lot: lot_4, proposal: proposal_5, supplier: supplier_2)
   end
 
   let!(:lot_proposal_6) do
     create(:lot_proposal, build_lot_group_item_lot_proposal: false,
-        lot: lot_3, proposal: proposal_6, supplier: supplier)
+        lot: lot_3, proposal: proposal_6, supplier: supplier_2)
   end
 
   let!(:lot_group_item_lot_proposal_1) do


### PR DESCRIPTION
Para as aplicações com dados é necessário executar o comando: 
```rb
LotProposal.group(:lot_id, :supplier_id).having("COUNT(*) > 1").count
```
para que seja retornado os lotes que possuem mais de um `LotProposal` por usuário.

Exemplo de retorno:
```rb
{[10, 55]=>2, [20, 54]=>2, [30, 50]=>2, [12, 54]=>2}
```

Onde temos `[10, 55]=>2` sendo:
- 10 = ID do lote (`:lot_id`);
- 55 = ID do usuario (`:supplier_id`);
- 2 = Total de `LotProposal`(`count`).

---

Neste caso temos que acessar o lote (ID 10) e listar as propostas de lote do usuário (ID 55) `lot_proposals.where(supplier_id: 55)`. Com isso serão retornadas 2 (nesse caso onde o _count_ retornou `2`) `LotProposal`. Verificar qual das 2 propostas será excluída para remover a duplicação excluindo o `Proposal` (que pode ser encontrado pela associação `lot_proposal.proposal`).

---

Após remover as duplicações deve-se então realizar o deploy da aplicação para que seja adicionado o novo índice no banco de dados.