### PR TITLE
Erro ao editar um lote de uma proposta #26

### DIFF
--- a/app/controllers/coop/biddings/lots_controller.rb
+++ b/app/controllers/coop/biddings/lots_controller.rb
@@ -50,7 +50,7 @@ module Coop
       ActiveRecord::Base.transaction do
         super && RecalculateQuantityService.call!(covenant: bidding.covenant)
 
-      rescue ActiveRecord::RecordInvalid
+      rescue => error
         raise ActiveRecord::Rollback
         return false
       end

--- a/app/models/lot_group_item.rb
+++ b/app/models/lot_group_item.rb
@@ -36,7 +36,7 @@ class LotGroupItem < ApplicationRecord
   private
 
   def ensure_quantity
-    self.quantity = quantity_before_type_cast.to_s.gsub(',', '.').to_f
+    self.quantity = quantity_before_type_cast.to_s.gsub(',', '.').to_d
   end
 
   def minimum_quantity
@@ -48,7 +48,7 @@ class LotGroupItem < ApplicationRecord
   end
 
   def max_quantity
-    new_record? ? group_item.available_quantity : group_item.available_quantity + quantity_was.to_f
+    new_record? ? group_item.available_quantity.to_d : group_item.available_quantity + quantity_was.to_d
   end
 
   def recount_group_item_quantity

--- a/app/services/recalculate_quantity_service.rb
+++ b/app/services/recalculate_quantity_service.rb
@@ -59,7 +59,7 @@ class RecalculateQuantityService
   end
 
   def active_lot_group_items_sum(group_item)
-    group_item.lot_group_items.active.sum(:quantity).to_f
+    group_item.lot_group_items.active.sum(:quantity).to_d
   end
 
   def active_returned_lot_group_items_sum(group_item)
@@ -93,6 +93,6 @@ class RecalculateQuantityService
   end
 
   def returned_items_sum(returned_lot_group_items)
-    @returned_items_sum[returned_lot_group_items.ids.join('-')] ||= returned_lot_group_items.sum(:quantity).to_f
+    @returned_items_sum[returned_lot_group_items.ids.join('-')] ||= returned_lot_group_items.sum(:quantity).to_d
   end
 end

--- a/spec/controllers/coop/biddings/lots_controller_spec.rb
+++ b/spec/controllers/coop/biddings/lots_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Coop::Biddings::LotsController, type: :controller do
             allow(RecalculateQuantityService).
               to receive(:call!).
               with(covenant: lot.bidding.covenant).
-              and_raise(ActiveRecord::RecordInvalid)
+              and_raise(RecalculateItemError)
 
             post_update
           end

--- a/spec/models/lot_group_item_spec.rb
+++ b/spec/models/lot_group_item_spec.rb
@@ -138,12 +138,12 @@ RSpec.describe LotGroupItem, type: :model do
             before do
               allow(lot_group_item).to receive(:new_record?) { true }
 
-              group_item.update_attribute(:available_quantity, 50)
+              group_item.update_attribute(:available_quantity, 50.29)
 
               lot_group_item.reload
             end
 
-            it { expect(lot_group_item.send(:max_quantity)).to eq 50 }
+            it { expect(lot_group_item.send(:max_quantity)).to eq 50.29 }
           end
 
           context 'when persisted' do


### PR DESCRIPTION
Atualização da comparação de quantidades para decimal ao invés de float, o qual pode gerar arredondamentos e consequentemente diferenças nas comparações.