### PR TITLE
Melhoria na checagem de propostas sem carregamento de parâmetros não necessários

### DIFF
--- a/app/services/biddings_service/reprove.rb
+++ b/app/services/biddings_service/reprove.rb
@@ -23,9 +23,10 @@ module BiddingsService
     end
 
     def updates_bidding_to_review
-      # we just update_attributes instead of draft! because we can get
-      # a record invalid from validate_start_date/closing_date (unwanted)
-      bidding.update_attributes(status: :draft)
+      # atualizando a situação com update_attribute para que a atualização seja
+      # possível mesmo que a licitação seja inválida - como por exemplo uma reprovação
+      # depois do seu dia de abertura
+      bidding.update_attribute(:status, :draft)
     end
 
     def attributes

--- a/app/services/blockchain/proposal/get.rb
+++ b/app/services/blockchain/proposal/get.rb
@@ -16,11 +16,14 @@ module Blockchain
         request
       end
 
-       def id
+      # gets doenst need params
+      def params; end
+
+      def id
         proposal.id
       end
 
-       def verb
+      def verb
         'GET'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  mount Sidekiq::Web => '/sidekiq'
-
   concern :notifiable do
     resources :notifications, only: [:index, :show] do
       patch :mark_as_read, on: :member
@@ -19,7 +17,7 @@ Rails.application.routes.draw do
 
   devise_for :users,
     module: 'coop',
-    path: 'cooperative', # removing /users from path]
+    path: 'cooperative', # removing /users from path
     skip: %i[sessions registrations] # we're using doorkeeper with tokens
 
   devise_for :suppliers,
@@ -221,5 +219,4 @@ Rails.application.routes.draw do
       resources :providers, only: :index
     end
   end
-
 end

--- a/spec/services/biddings_service/reprove_spec.rb
+++ b/spec/services/biddings_service/reprove_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe BiddingsService::Reprove, type: :service do
   describe 'call' do
     context 'when success' do
       before do
+        # forçando a bidding a ser inválida para testar o update_attribute
+        bidding.update_attribute(:deadline, nil)
         allow(Notifications::Biddings::Reproved).to receive(:call).with(bidding).and_call_original
 
         service.call
@@ -37,7 +39,7 @@ RSpec.describe BiddingsService::Reprove, type: :service do
 
     context 'when failure' do
       before do
-        allow(bidding).to receive(:update_attributes) { raise ActiveRecord::RecordInvalid }
+        allow(service.event).to receive(:save!) { raise ActiveRecord::RecordInvalid }
         allow(Notifications::Biddings::Reproved).to receive(:call).with(bidding).and_call_original
 
         service.call

--- a/spec/services/blockchain/proposal/delete_spec.rb
+++ b/spec/services/blockchain/proposal/delete_spec.rb
@@ -5,7 +5,7 @@ require './lib/api_blockchain/client'
 RSpec.describe Blockchain::Proposal::Delete do
   let(:proposal) { create(:proposal) }
   let(:lot_proposal) { proposal.lot_proposals.first }
-  let(:lot_group_item_lp) { lot_proposal.lot_group_item_lot_proposals.first } 
+  let(:lot_group_item_lp) { lot_proposal.lot_group_item_lot_proposals.first }
 
   let!(:service) { described_class.new(proposal) }
   let!(:verb) { 'DELETE' }
@@ -23,8 +23,11 @@ RSpec.describe Blockchain::Proposal::Delete do
   let(:endpoint) { described_class::ENDPOINT + "/#{proposal.id}" }
 
   describe 'endpoint' do
-
     it { expect(service.send(:endpoint)).to eq endpoint }
+  end
+
+  describe 'params' do
+    it { expect(service.send(:params)).to be_nil }
   end
 
   describe 'call' do

--- a/spec/services/blockchain/proposal/get_spec.rb
+++ b/spec/services/blockchain/proposal/get_spec.rb
@@ -49,8 +49,14 @@ RSpec.describe Blockchain::Proposal::Get do
     }
   end
 
+  let(:endpoint) { described_class::ENDPOINT + "/#{proposal.id}" }
+
+  describe 'endpoint' do
+    it { expect(service.send(:endpoint)).to eq endpoint }
+  end
+
   describe 'params' do
-    it { expect(service.send(:params)).to eq fake_body }
+    it { expect(service.send(:params)).to be_nil }
   end
 
    describe 'call' do


### PR DESCRIPTION
Na chamada de checagem de propostas (Get) não é necessário o carregamento dos parâmetros, uma vez que estamos realizando apenas um get e não um post/patch/put.