### PR TITLE
Erro ao criar lote em licitação rascunho do convênio 054718

### DIFF
--- a/app/services/recalculate_quantity_service.rb
+++ b/app/services/recalculate_quantity_service.rb
@@ -32,7 +32,6 @@ class RecalculateQuantityService
         else
           debit_the_available_quantity(lot_group_item.group_item)
         end
-        credit_the_returned_items(lot_group_item.group_item)
       end
     end
   end
@@ -44,18 +43,12 @@ class RecalculateQuantityService
   end
 
   def debit_the_available_quantity(group_item)
-    group_item.update!(available_quantity: group_item.quantity - active_lot_group_items_sum(group_item))
+    returned_items_sum = active_lot_group_items_sum(group_item) - active_returned_lot_group_items_sum(group_item)
+    group_item.update!(available_quantity: group_item.quantity - returned_items_sum)
   end
 
   def credit_the_available_quantity(group_item, quantity)
     group_item.update!(available_quantity: group_item.available_quantity + quantity)
-  end
-
-  def credit_the_returned_items(group_item)
-    returned_items_sum = active_returned_lot_group_items_sum(group_item)
-    if returned_items_sum > 0
-      group_item.update!(available_quantity: group_item.available_quantity + returned_items_sum)
-    end
   end
 
   def active_lot_group_items_sum(group_item)

--- a/spec/services/recalculate_quantity_service_spec.rb
+++ b/spec/services/recalculate_quantity_service_spec.rb
@@ -1,20 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe RecalculateQuantityService do
-  let(:bidding) { create(:bidding, status: :ongoing) }
-  let(:covenant) { bidding.covenant }
+  let(:bidding)     { create(:bidding, status: :ongoing) }
+  let(:covenant)    { bidding.covenant }
   let!(:group_item) { create(:group_item, quantity: group_item_quantity) }
-  let(:lot) { bidding.lots.first }
+  let(:lot)         { bidding.lots.first }
   let(:another_lot) { create(:lot, bidding: bidding, status: :canceled) }
   let!(:lot_group_item) do
-    create(:lot_group_item, group_item: group_item, lot: lot, quantity: 100)
+    create(:lot_group_item, group_item: group_item, lot: lot, quantity: lot_group_item_quantity)
   end
   let!(:another_lot_group_item) do
-    create(:lot_group_item, group_item: group_item, lot: another_lot, quantity: 50)
+    create(:lot_group_item, group_item: group_item, lot: another_lot, quantity: another_lot_group_item_quantity)
   end
-  let(:group_item_quantity) { 200.5 }
-  let(:params) { { covenant: covenant } }
-  let(:expected) { 100.5 }
+  let(:params)                          { { covenant: covenant } }
+  let(:group_item_quantity)             { 200.5 }
+  let(:lot_group_item_quantity)         { 100 }
+  let(:another_lot_group_item_quantity) { 50 }
+  let(:expected)                        { 100.5 }
 
   describe '#initialize' do
     subject { described_class.new(params) }
@@ -38,7 +40,7 @@ RSpec.describe RecalculateQuantityService do
         end
 
         context 'and the bidding has contracts' do
-          let(:user) { create(:user) }
+          let(:user)     { create(:user) }
           let(:proposal) { create(:proposal, bidding: bidding) }
           let!(:contract) do
             create(:contract, status: :partial_execution, proposal: proposal,
@@ -67,7 +69,7 @@ RSpec.describe RecalculateQuantityService do
         end
 
         context 'and the bidding has contracts' do
-          let(:user) { create(:user) }
+          let(:user)     { create(:user) }
           let(:proposal) { create(:proposal, bidding: bidding) }
           let!(:contract) do
             create(:contract, status: :partial_execution, proposal: proposal,
@@ -83,9 +85,51 @@ RSpec.describe RecalculateQuantityService do
         end
       end
 
-      context 'and the lot_group_item is destroyed' do
+      context 'and has only one item with returned quantity' do
+        let(:proposal) { create(:proposal, bidding: bidding) }
+        let(:contract) { create(:contract, proposal: proposal) }
+        let!(:returned_lot_group_item) do
+          create(:returned_lot_group_item, contract: contract,
+                 lot_group_item: lot_group_item,
+                 quantity: returned_lot_group_item_quantity)
+        end
+        let(:group_item_quantity)              { 1 }
+        let(:available_quantity)               { 1 }
+        let(:lot_group_item_quantity)          { 2 }
+        let(:returned_lot_group_item_quantity) { 1 }
+        let(:expected)                         { 0 }
+
         before do
-          subject
+          bidding.lot_group_items.select{ |l| l.id != lot_group_item.id }.each(&:destroy!)
+          group_item.update_column(:available_quantity, available_quantity)
+          bidding.reload
+        end
+
+        it { is_expected.to be_truthy }
+        it do
+          expect { subject }.
+            to change { group_item.reload.available_quantity }.
+            from(group_item_quantity).to(expected)
+        end
+      end
+
+      context 'and the lot_group_item is destroyed' do
+        let(:proposal) { create(:proposal, bidding: bidding) }
+        let(:contract) { create(:contract, proposal: proposal) }
+        let!(:returned_lot_group_item) do
+          create(:returned_lot_group_item, contract: contract,
+                 lot_group_item: lot_group_item,
+                 quantity: returned_lot_group_item_quantity)
+        end
+        let(:group_item_quantity)              { 10 }
+        let(:available_quantity)               { 5 }
+        let(:lot_group_item_quantity)          { 5 }
+        let(:returned_lot_group_item_quantity) { 1 }
+
+        before do
+          bidding.lot_group_items.select{ |l| l.id != lot_group_item.id }.each(&:destroy!)
+          group_item.update_column(:available_quantity, available_quantity)
+          bidding.reload
           lot_group_item.destroy!
         end
 


### PR DESCRIPTION
Issue: https://github.com/SolucaoOnlineDeLicitacao/sol-api/issues/34

---

O problema é no método `debit_the_available_quantity`, onde está sendo feito o cálculo de 1 - 2 retornando um valor de -1 para a quantidade disponível, o que ocasiona o erro.

```ruby
group_item.update!(available_quantity: group_item.quantity - active_lot_group_items_sum(group_item)
```

Os valores estão corretos, então a solução consiste em calcular os items ativos junto com os items retornados.