### PR TITLE
Erro Licitação 3469/2020

### DIFF
--- a/app/services/proposal_service/admin/lot_proposal/refuse.rb
+++ b/app/services/proposal_service/admin/lot_proposal/refuse.rb
@@ -5,7 +5,7 @@ module ProposalService::Admin::LotProposal
     private
 
     def refuse_lots!
-      lot.failure! if only_refused_or_abandoned_proposals?
+      lot.failure! if only_allowed_statuses?
     end
 
     def proposal_status

--- a/app/services/proposal_service/admin/refuse.rb
+++ b/app/services/proposal_service/admin/refuse.rb
@@ -5,7 +5,7 @@ module ProposalService::Admin
     private
 
     def refuse_lots!
-      lots.map(&:failure!) if only_refused_or_abandoned_proposals?
+      lots.map(&:failure!) if only_allowed_statuses?
     end
 
     def proposal_status

--- a/app/services/proposal_service/admin/refuse_base.rb
+++ b/app/services/proposal_service/admin/refuse_base.rb
@@ -3,7 +3,7 @@ module ProposalService::Admin
     include Call::Methods
     include TransactionMethods
 
-    ALLOWED_STATUSES = %w(refused abandoned).freeze
+    ALLOWED_STATUSES = %w(refused abandoned failure).freeze
 
     def main_method
       change_proposal_to_refused
@@ -20,7 +20,7 @@ module ProposalService::Admin
       end
     end
 
-    def only_refused_or_abandoned_proposals?
+    def only_allowed_statuses?
       proposal_status.all? { |status| ALLOWED_STATUSES.include? status }
     end
 


### PR DESCRIPTION
Issue: https://github.com/SolucaoOnlineDeLicitacao/sol-api/issues/39

---

O que acontece nesse caso específico, é que os status dos lotes "Em análise" não foram alterados para "Fracassado" ao Revisor aceitar a recusa das propostas.
Sem essa alteração de status para "Fracassado" o sistema entende que ainda não foi concluída a licitação, não habilitando o botão.
Para o lote estar "Fracassado" as propostas desse lote precisam estar com os status "Recusada" ou "Abandonada", no caso da issue tem uma proposta com o status "Contrato Recusado". O aceite da recusa pelo revisor não estava considerando esse status de proposta.

---

Para prosseguir com a Licitação 3469/2020 (aparecer o botão "CONCLUIR LICITAÇÃO") é preciso corrigir o status desses dois lotes "Em análise" para "Fracassado".

No console do _Rails_ executar o comando abaixo:

```ruby
Bidding.find(3469).lots.where(status: :triage).update_all(status: :failure)
```