### PR TITLE
Adição de componente "Adicionar Grupo" para um cadastro/edição de uma licitação

### DIFF
--- a/app/controllers/coop/covenants/groups_controller.rb
+++ b/app/controllers/coop/covenants/groups_controller.rb
@@ -1,5 +1,7 @@
 module Coop
   class Covenants::GroupsController < CoopController
+    include CrudController
+
     load_and_authorize_resource :group, parent: false
 
     expose :covenant
@@ -7,17 +9,21 @@ module Coop
     expose :group
 
     def index
-      render json: groups, each_serializer: Coop::GroupSerializer
+      render json: paginated_resources, each_serializer: Coop::GroupSerializer
     end
 
     def show
-      render json: group, serializer: Coop::GroupSerializer
+      render json: resource, serializer: Coop::GroupSerializer
     end
 
     private
 
     def find_groups
       covenant.groups.accessible_by(current_ability)
+    end
+
+    def resources
+      groups
     end
 
     def resource

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,7 @@
 class Group < ApplicationRecord
+  include Group::Search
+  include ::Sortable
+
   versionable
 
   belongs_to :covenant
@@ -10,4 +13,8 @@ class Group < ApplicationRecord
   validates_uniqueness_of :name, scope: :covenant_id
 
   accepts_nested_attributes_for :group_items, allow_destroy: true
+
+  def self.default_sort_column
+    'groups.name'
+  end
 end

--- a/app/models/group/search.rb
+++ b/app/models/group/search.rb
@@ -1,0 +1,12 @@
+#
+# Métodos e constantes de busca para Grupos
+#
+
+module Group::Search
+  extend ActiveSupport::Concern
+  include Searchable
+
+  SEARCH_EXPRESSION = %q{
+    unaccent(LOWER(groups.name)) LIKE unaccent(LOWER(:search))
+  }
+end

--- a/app/serializers/concerns/group_item_serializable.rb
+++ b/app/serializers/concerns/group_item_serializable.rb
@@ -3,7 +3,7 @@ module GroupItemSerializable
 
   included do
     attributes :id, :item_id, :item_short_name, :item_name, :item_unit, :quantity,
-               :available_quantity, :group_name, :estimated_cost, :_destroy
+               :available_quantity, :group_id, :group_name, :estimated_cost, :_destroy
   end
 
   def item_name
@@ -16,6 +16,10 @@ module GroupItemSerializable
 
   def item_unit
     object.item.unit_name
+  end
+
+  def group_id
+    object.group_id
   end
 
   def group_name

--- a/app/serializers/coop/lot_group_item_serializer.rb
+++ b/app/serializers/coop/lot_group_item_serializer.rb
@@ -2,7 +2,7 @@ module Coop
   class LotGroupItemSerializer < ActiveModel::Serializer
     attributes :id, :lot_id, :group_item_id, :item_short_name,
                 :item_name, :item_unit, :quantity, :current_quantity, :total_quantity,
-                :available_quantity, :lot_group_item_count, :_destroy, :lot_name
+                :available_quantity, :lot_group_item_count, :_destroy, :lot_name, :group_id
 
     def quantity
       object.quantity.to_f
@@ -38,6 +38,10 @@ module Coop
 
     def lot_name
       object.lot.name
+    end
+
+    def group_id
+      object.group_item.group_id
     end
   end
 end

--- a/spec/controllers/coop/covenants/groups_controller_spec.rb
+++ b/spec/controllers/coop/covenants/groups_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe Coop::Covenants::GroupsController, type: :controller do
+  let(:serializer) { Coop::GroupSerializer }
+  let(:covenant) { create(:covenant, group: false) }
+  let(:cooperative) { covenant.cooperative }
+  let(:user) { create(:user, cooperative: cooperative) }
+
+  let!(:groups) { create_list(:group, 2, covenant: covenant) }
+  let(:group) { groups.first }
+
+  before { oauth_token_sign_in user }
+
+  describe '#index' do
+    let(:params) { { covenant_id: covenant } }
+
+    subject(:get_index) { get :index, params: params, xhr: true }
+
+    it_behaves_like 'an user authorization to', 'read'
+    it_behaves_like 'a scope to' do
+      let(:resource) { Group }
+    end
+
+    describe 'helpers' do
+      let!(:params) do
+        { covenant_id: covenant, search: 'search', page: 2, sort_column: 'name', sort_direction: 'desc' }
+      end
+
+      let(:exposed_groups) { Group.all }
+
+      before do
+        allow(exposed_groups).to receive(:search) { exposed_groups }
+        allow(exposed_groups).to receive(:sorted) { exposed_groups }
+        allow(exposed_groups).to receive(:page).with(anything()).and_call_original
+        allow(controller).to receive(:groups) { exposed_groups }
+
+        get_index
+      end
+
+      it { expect(exposed_groups).to have_received(:search).with('search') }
+      it { expect(exposed_groups).to have_received(:sorted).with('name', 'desc') }
+      it { expect(exposed_groups).to have_received(:page).at_least(:once).with(2) }
+      it { expect(described_class::PER_PAGE).to eq 20 }
+    end
+
+    describe 'response' do
+      before { get_index }
+
+      describe 'http_status' do
+        it { expect(response).to have_http_status :ok }
+      end
+
+      describe 'exposes' do
+        it { expect(controller.groups).to match_array groups }
+      end
+
+      describe 'JSON' do
+        let(:json) { JSON.parse(response.body) }
+        let(:expected_json) { groups.map { |group| format_json(serializer, group) } }
+
+        it { expect(json).to match_array expected_json }
+      end
+    end
+  end
+
+  describe '#show' do
+    let(:params) { { covenant_id: covenant, id: group } }
+
+    before { get_show }
+
+    subject(:get_show) { get :show, params: params, xhr: true }
+
+    it_behaves_like 'an user authorization to', 'read'
+
+    describe 'http_status' do
+      it { expect(response).to have_http_status :ok }
+    end
+
+    describe 'exposes' do
+      it { expect(controller.group).to eq group }
+    end
+
+     describe 'JSON' do
+      let(:json) { JSON.parse(response.body) }
+      let(:expected_json) { format_json(serializer, group) }
+
+      it { expect(json).to eq expected_json }
+    end
+  end
+end

--- a/spec/models/group/search_spec.rb
+++ b/spec/models/group/search_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group::Search do
+  it { is_expected.to be_unaccent_searchable_like('groups.name') }
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Group, type: :model do
     it { is_expected.to accept_nested_attributes_for(:group_items).allow_destroy(true) }
   end
 
+  describe 'sortable' do
+    it { expect(described_class.default_sort_column).to eq 'groups.name' }
+  end
+
   describe 'behaviors' do
     it { is_expected.to be_versionable }
   end

--- a/spec/serializers/coop/lot_group_item_serializer_spec.rb
+++ b/spec/serializers/coop/lot_group_item_serializer_spec.rb
@@ -26,5 +26,6 @@ RSpec.describe Coop::LotGroupItemSerializer, type: :serializer do
     it { is_expected.to include '_destroy' => object._destroy }
     it { is_expected.to include 'lot_group_item_count' => lot_group_item_count }
     it { is_expected.to include 'lot_name' => lot_name }
+    it { is_expected.to include 'group_id' => object.group_item.group_id }
   end
 end

--- a/spec/support/shared_examples/serializers/concerns/group_item_serializer.rb
+++ b/spec/support/shared_examples/serializers/concerns/group_item_serializer.rb
@@ -11,6 +11,7 @@ RSpec.shared_examples "a group_item_serializer" do
     it { is_expected.to include 'item_unit' => object.item.unit_name }
     it { is_expected.to include 'quantity' => object.quantity }
     it { is_expected.to include 'available_quantity' => object.available_quantity }
+    it { is_expected.to include 'group_id' => object.group_id }
     it { is_expected.to include 'group_name' => object.group.name }
     it { is_expected.to include 'estimated_cost' => object.estimated_cost }
     it { is_expected.to include '_destroy' => object._destroy }


### PR DESCRIPTION
Adaptação da API para suportar a nova funcionalidade de "Adicionar Grupo".

![image](https://user-images.githubusercontent.com/22406399/99285562-71e29b80-2816-11eb-8ced-5b9b016e1daa.png)
