### PR TITLE
Remove valor por extenso do edital e contrato para valores não permitidos

### DIFF
--- a/config/locales/pdf.en-US.yml
+++ b/config/locales/pdf.en-US.yml
@@ -29,8 +29,10 @@
           global_text: "For procurement process <b>%s</b><br/>"
           lot_text: "For lot <b>%s - %s</b><br/>"
           proposal_line: "company %s submitted a proposal with a value of %s (%s)"
+          proposal_line_without_text_value: "company %s submitted a proposal with a value of %s"
           bidding_comment_text: "The proposal of vendor %s received comments:<br/>"
           proposals_accepted: "Company %s / %s was declared the winner with a value of %s (%s), considering that it was the lowest value and fully compliant with the Term of Reference established by the Cooperative."
+          proposals_accepted_without_text_value: "Company %s / %s was declared the winner with a value of %s, considering that it was the lowest value and fully compliant with the Term of Reference established by the Cooperative."
           contract_refused: "Contract %s was rejected by vendor %s due to %s"
           contract_total_inexecution: "Contract %s with vendor %s / CNPJ %s was updated to “complete nonperformance” status by the cooperative %s."
           no_proposals: No winning company.

--- a/config/locales/pdf.es-PY.yml
+++ b/config/locales/pdf.es-PY.yml
@@ -29,8 +29,10 @@
           global_text: "Para la licitación <b>%s</b><br/>"
           lot_text: "Para el lote <b>%s - %s</b><br/>"
           proposal_line: "la empresa %s ha presentado la propuesta por un valor de %s (%s)"
+          proposal_line_without_text_value: "la empresa %s ha presentado la propuesta por un valor de %s"
           bidding_comment_text: "La propuesta del proveedor %s ha recibido los comentarios:<br/>"
           proposals_accepted: "La empresa %s / %s ha sido declarada ganadora por el valor de %s (%s), teniendo en cuenta que fue la que presentó la propuesta de menor valor y de conformidad con los Términos de referencia presentados por la asociación."
+          proposals_accepted_without_text_value: "La empresa %s / %s ha sido declarada ganadora por el valor de %s, teniendo en cuenta que fue la que presentó la propuesta de menor valor y de conformidad con los Términos de referencia presentados por la asociación."
           contract_refused: "El contrato %s ha sido rechazado por el proveedor %s por el/los motivo/s %s"
           contract_total_inexecution: "El contrato %s con el proveedor %s / CNPJ %s ha sido actualizado para la situación de falta de ejecución total por la asociación %s."
           no_proposals: Ninguna empresa ganadora.

--- a/config/locales/pdf.pt-BR.yml
+++ b/config/locales/pdf.pt-BR.yml
@@ -29,8 +29,10 @@ pt-BR:
           global_text: "Para a licitação <b>%s</b><br/>"
           lot_text: "Para o lote <b>%s - %s</b><br/>"
           proposal_line: "a empresa %s apresentou proposta no valor de %s (%s)"
+          proposal_line_without_text_value: "a empresa %s apresentou proposta no valor de %s"
           bidding_comment_text: "A proposta do fornecedor %s recebeu os comentários:<br/>"
           proposals_accepted: "A empresa %s / %s foi declarada vencedora com valor %s (%s), tendo em vista que foi a que apresentou a proposta de menor valor e em conformidade com o Termo de Referência apresentado pela Associação."
+          proposals_accepted_without_text_value: "A empresa %s / %s foi declarada vencedora com valor %s, tendo em vista que foi a que apresentou a proposta de menor valor e em conformidade com o Termo de Referência apresentado pela Associação."
           contract_refused: "O contrato %s foi recusado pelo fornecedor %s pelo(s) motivo(s) %s"
           contract_total_inexecution: "O contrato %s com o fornecedor %s / CNPJ %s foi atualizado para a situação de inexecução total pela associação %s."
           no_proposals: Nenhuma empresa vencedora.

--- a/lib/pdf/bidding/minute/addendum/base.rb
+++ b/lib/pdf/bidding/minute/addendum/base.rb
@@ -2,6 +2,7 @@ module Pdf::Bidding::Minute
   class Addendum::Base
     include Call::Methods
     include ActionView::Helpers::NumberHelper
+    include Pdf::HelperMethods
 
     attr_accessor :html
 
@@ -78,10 +79,17 @@ module Pdf::Bidding::Minute
       return "" if proposal.blank?
 
       proposal_value = format_currency(proposal.price_total)
-      proposal_text = Extenso.moeda(prepare_currency(proposal_value))
+      proposal_value_prepared = prepare_currency(proposal_value)
 
-      I18n.t('document.pdf.bidding.minute.proposals_accepted') %
-        [proposal.provider.name, proposal.provider.document, proposal_value, proposal_text]
+      if valid_value_for_full_text?(proposal_value_prepared)
+        proposal_text = Extenso.moeda(proposal_value_prepared)
+
+        I18n.t('document.pdf.bidding.minute.proposals_accepted') %
+          [proposal.provider.name, proposal.provider.document, proposal_value, proposal_text]
+      else
+        I18n.t('document.pdf.bidding.minute.proposals_accepted_without_text_value') %
+          [proposal.provider.name, proposal.provider.document, proposal_value]
+      end
     end
 
     def global_text

--- a/lib/pdf/bidding/minute/base.rb
+++ b/lib/pdf/bidding/minute/base.rb
@@ -2,6 +2,7 @@ module Pdf::Bidding
   class Minute::Base
     include Call::Methods
     include ActionView::Helpers::NumberHelper
+    include Pdf::HelperMethods
 
     attr_accessor :html
 
@@ -99,10 +100,18 @@ module Pdf::Bidding
 
     def proposal_line(proposal)
       proposal_value = format_currency(proposal.price_total)
-      proposal_text = Extenso.moeda(prepare_currency(proposal_value))
+      proposal_value_prepared = prepare_currency(proposal_value)
 
-      I18n.t('document.pdf.bidding.minute.proposal_line') %
-        [proposal.provider.name, proposal_value, proposal_text]
+      if valid_value_for_full_text?(proposal_value_prepared)
+        proposal_text = Extenso.moeda(proposal_value_prepared)
+
+        I18n.t('document.pdf.bidding.minute.proposal_line') %
+          [proposal.provider.name, proposal_value, proposal_text]
+      else
+        I18n.t('document.pdf.bidding.minute.proposal_line_without_text_value') %
+          [proposal.provider.name, proposal_value]
+      end
+
     end
 
     def bidding_proposals_accepted
@@ -121,10 +130,17 @@ module Pdf::Bidding
       return I18n.t('document.pdf.bidding.minute.no_proposals') if proposal.blank?
 
       proposal_value = format_currency(proposal.price_total)
-      proposal_text = Extenso.moeda(prepare_currency(proposal_value))
+      proposal_value_prepared = prepare_currency(proposal_value)
 
-      I18n.t('document.pdf.bidding.minute.proposals_accepted') %
-        [proposal.provider.name, proposal.provider.document, proposal_value, proposal_text]
+      if valid_value_for_full_text?(proposal_value_prepared)
+        proposal_text = Extenso.moeda(proposal_value_prepared)
+
+        I18n.t('document.pdf.bidding.minute.proposals_accepted') %
+          [proposal.provider.name, proposal.provider.document, proposal_value, proposal_text]
+      else
+        I18n.t('document.pdf.bidding.minute.proposals_accepted_without_text_value') %
+          [proposal.provider.name, proposal.provider.document, proposal_value]
+      end
     end
 
     def bidding_comments_sentence

--- a/lib/pdf/contract/classification/base.rb
+++ b/lib/pdf/contract/classification/base.rb
@@ -2,6 +2,7 @@ module Pdf::Contract::Classification
   class Base
     include Call::Methods
     include ActionView::Helpers::NumberHelper
+    include Pdf::HelperMethods
 
     attr_accessor :html, :table, :template
 
@@ -225,7 +226,8 @@ module Pdf::Contract::Classification
     end
 
     def total_full_value
-      Extenso.moeda(prepare_currency(formatted_total_value))
+      value = prepare_currency(formatted_total_value)
+      valid_value_for_full_text?(value) ? Extenso.moeda(value) : nil
     end
 
     def total_value

--- a/lib/pdf/helper_methods.rb
+++ b/lib/pdf/helper_methods.rb
@@ -1,0 +1,7 @@
+module Pdf
+  module HelperMethods
+    def valid_value_for_full_text?(value)
+      value >= 1 && value <= 999999999
+    end
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/SolucaoOnlineDeLicitacao/sol-api/issues/42

---

A _gem_ `extensobr` não aceita valores fora do limite 1 e 999999999, o valor que esta sendo gerado na ATA está fora desse limite.
Foi adicionada uma condição de que se o valor estiver fora desse limite, não gere o valor por extenso na ATA, apenas o valor numérico.