### PR TITLE
Ciclo II - SOL

### DIFF
--- a/app/controllers/administrator/cooperatives_controller.rb
+++ b/app/controllers/administrator/cooperatives_controller.rb
@@ -9,7 +9,7 @@ module Administrator
 
       address_attributes: [
         :id, :address, :number, :neighborhood, :city_id, :cep, :complement,
-        :reference_point, :latitude, :longitude, :phone, :email
+        :reference_point, :latitude, :longitude
       ],
 
       legal_representative_attributes: [
@@ -17,7 +17,7 @@ module Administrator
 
         address_attributes: [
           :id, :address, :number, :neighborhood, :city_id, :cep, :complement,
-          :reference_point, :latitude, :longitude, :phone, :email
+          :reference_point, :latitude, :longitude
         ]
 
       ]

--- a/app/controllers/administrator/cooperatives_controller.rb
+++ b/app/controllers/administrator/cooperatives_controller.rb
@@ -9,7 +9,7 @@ module Administrator
 
       address_attributes: [
         :id, :address, :number, :neighborhood, :city_id, :cep, :complement,
-        :reference_point, :latitude, :longitude
+        :reference_point, :latitude, :longitude, :phone, :email
       ],
 
       legal_representative_attributes: [
@@ -17,7 +17,7 @@ module Administrator
 
         address_attributes: [
           :id, :address, :number, :neighborhood, :city_id, :cep, :complement,
-          :reference_point, :latitude, :longitude
+          :reference_point, :latitude, :longitude, :phone, :email
         ]
 
       ]

--- a/app/models/abilities/admin/reviewer_ability.rb
+++ b/app/models/abilities/admin/reviewer_ability.rb
@@ -21,7 +21,6 @@ module Abilities::Admin
         can :manage, GroupItem, group_rule
       end
 
-      can :read,   Bidding
       can :manage, Contract, bidding_rule
       can :manage, Bidding, covenant_rule
       can :manage, Proposal, bidding_rule

--- a/app/models/abilities/admin/reviewer_ability.rb
+++ b/app/models/abilities/admin/reviewer_ability.rb
@@ -21,6 +21,7 @@ module Abilities::Admin
         can :manage, GroupItem, group_rule
       end
 
+      can :read,   Bidding
       can :manage, Contract, bidding_rule
       can :manage, Bidding, covenant_rule
       can :manage, Proposal, bidding_rule

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -13,7 +13,6 @@ class Address < ApplicationRecord
             :number,
             :neighborhood,
             :reference_point,
-            :phone,
             presence: true
 
   with_options unless: -> { skip_integration_validations } do |model|

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -13,6 +13,7 @@ class Address < ApplicationRecord
             :number,
             :neighborhood,
             :reference_point,
+            :phone,
             presence: true
 
   with_options unless: -> { skip_integration_validations } do |model|

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,7 +1,7 @@
 class AddressSerializer < ActiveModel::Serializer
 
-  attributes :id, :latitude, :longitude, :city_name, :city_id, :address,
-              :number, :neighborhood, :cep, :complement, :reference_point
+  attributes :id, :latitude, :longitude, :city_name, :city_id, :address, :number,
+               :neighborhood, :cep, :complement, :reference_point, :phone, :email
 
   belongs_to :city
 

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,7 +1,7 @@
 class AddressSerializer < ActiveModel::Serializer
 
-  attributes :id, :latitude, :longitude, :city_name, :city_id, :address, :number,
-               :neighborhood, :cep, :complement, :reference_point, :phone, :email
+  attributes :id, :latitude, :longitude, :city_name, :city_id, :address,
+              :number, :neighborhood, :cep, :complement, :reference_point
 
   belongs_to :city
 

--- a/app/serializers/coop/bidding_serializer.rb
+++ b/app/serializers/coop/bidding_serializer.rb
@@ -7,8 +7,7 @@ module Coop
         :cancel_comment, :comment_response, :event_status, :event_id, :address,
         :can_finish, :supp_can_see, :modality, :draw_end_days, :refuse_comment,
         :failure_comment, :minute_pdf, :edict_pdf, :classification_id, :classification_name,
-        :all_lots_failure, :code, :position, :estimated_cost_total, :proposal_import_file_url,
-        :user_role
+        :all_lots_failure, :code, :position, :estimated_cost_total, :proposal_import_file_url
 
     has_one :cooperative, through: :covenant, serializer: Supp::CooperativeSerializer
 
@@ -62,10 +61,6 @@ module Coop
 
     def all_lots_failure
       object.fully_failed_lots?
-    end
-
-    def user_role
-      current_user.class == Admin ? current_user.role : ''
     end
 
     private

--- a/app/serializers/coop/bidding_serializer.rb
+++ b/app/serializers/coop/bidding_serializer.rb
@@ -7,7 +7,8 @@ module Coop
         :cancel_comment, :comment_response, :event_status, :event_id, :address,
         :can_finish, :supp_can_see, :modality, :draw_end_days, :refuse_comment,
         :failure_comment, :minute_pdf, :edict_pdf, :classification_id, :classification_name,
-        :all_lots_failure, :code, :position, :estimated_cost_total, :proposal_import_file_url
+        :all_lots_failure, :code, :position, :estimated_cost_total, :proposal_import_file_url,
+        :user_role
 
     has_one :cooperative, through: :covenant, serializer: Supp::CooperativeSerializer
 
@@ -61,6 +62,10 @@ module Coop
 
     def all_lots_failure
       object.fully_failed_lots?
+    end
+
+    def user_role
+      current_user.class == Admin ? current_user.role : ''
     end
 
     private

--- a/app/serializers/coop/bidding_serializer.rb
+++ b/app/serializers/coop/bidding_serializer.rb
@@ -7,7 +7,8 @@ module Coop
         :cancel_comment, :comment_response, :event_status, :event_id, :address,
         :can_finish, :supp_can_see, :modality, :draw_end_days, :refuse_comment,
         :failure_comment, :minute_pdf, :edict_pdf, :classification_id, :classification_name,
-        :all_lots_failure, :code, :position, :estimated_cost_total, :proposal_import_file_url
+        :all_lots_failure, :code, :position, :estimated_cost_total, :proposal_import_file_url,
+        :user_role
 
     has_one :cooperative, through: :covenant, serializer: Supp::CooperativeSerializer
 
@@ -61,6 +62,10 @@ module Coop
 
     def all_lots_failure
       object.fully_failed_lots?
+    end
+
+    def user_role
+      self.scope.class == Admin ? self.scope.role : ''
     end
 
     private

--- a/app/services/biddings_service/finish.rb
+++ b/app/services/biddings_service/finish.rb
@@ -25,18 +25,9 @@ module BiddingsService
 
           recalculate_quantity!
 
-          return desert_and_clone_bidding! if bidding_havent_proposals?
-
           finish_bidding!
         end
       end
-    end
-
-    def desert_and_clone_bidding!
-      bidding.desert!
-      bidding.reload
-      update_bidding_blockchain!
-      clone_bidding!
     end
 
     def finish_bidding!
@@ -58,10 +49,6 @@ module BiddingsService
       end
     end
 
-    def bidding_havent_proposals?
-      bidding.proposals.not_draft_or_abandoned.empty?
-    end
-
     def recalculate_quantity!
       RecalculateQuantityService.call!(covenant: bidding.covenant)
     end
@@ -74,10 +61,6 @@ module BiddingsService
       ContractsService::Create::Strategy::Finnished.call!(
         bidding: bidding, user: user
       )
-    end
-
-    def clone_bidding!
-      BiddingsService::Clone.call!(bidding: bidding)
     end
 
     def notify

--- a/app/services/biddings_service/review.rb
+++ b/app/services/biddings_service/review.rb
@@ -17,20 +17,17 @@ module BiddingsService
           common_review!
         end
 
-        bidding.under_review!
-        bidding.reload
+        return desert_and_clone_bidding! if proposals_not_draft_or_abandoned.empty?
 
-        raise BlockchainError unless blockchain_bidding_update.success?
-
-        Notifications::Biddings::UnderReview.call(bidding)
+        under_review_and_notify!
       end
     end
 
     def global_review!
-      if global_proposals.present?
+      if proposals_not_draft_or_abandoned.present?
         lots.map(&:triage!)
 
-        update_proposals(global_proposals)
+        update_proposals(proposals_not_draft_or_abandoned)
       else
         lots.map(&:desert!)
       end
@@ -39,7 +36,7 @@ module BiddingsService
     def common_review!
       lots.find_each do |lot|
         # only sent or draw proposals - cant have abandoned/draft ones
-        proposals = lot.proposals.where.not(status: [:draft, :abandoned])
+        proposals = lot.proposals.not_draft_or_abandoned
 
         if proposals.present?
           lot.triage!
@@ -51,8 +48,24 @@ module BiddingsService
       end
     end
 
-    def blockchain_bidding_update
-      Blockchain::Bidding::Update.call(bidding)
+    def desert_and_clone_bidding!
+      bidding.desert!
+      bidding.reload
+      blockchain_bidding_update!
+      BiddingsService::Clone.call!(bidding: bidding)
+      generate_minute
+    end
+
+    def under_review_and_notify!
+      bidding.under_review!
+      bidding.reload
+      blockchain_bidding_update!
+      Notifications::Biddings::UnderReview.call(bidding)
+    end
+
+    def blockchain_bidding_update!
+      response = Blockchain::Bidding::Update.call(bidding)
+      raise BlockchainError unless response.success?
     end
 
     def update_proposals(proposals)
@@ -63,13 +76,16 @@ module BiddingsService
       proposals.sent.lower&.triage!
     end
 
-    def global_proposals
-      # only sent or draw proposals - cant have abandoned/draft ones
-      @global_proposals ||= bidding.proposals.where.not(status: [:draft, :abandoned])
+    def proposals_not_draft_or_abandoned
+      @proposals_not_draft_or_abandoned ||= bidding.proposals.not_draft_or_abandoned
     end
 
     def lots
       @lots ||= bidding.lots
+    end
+
+    def generate_minute
+      Bidding::Minute::PdfGenerateWorker.perform_async(bidding.id)
     end
   end
 end

--- a/db/migrate/20210323212351_add_phone_and_email_to_address.rb
+++ b/db/migrate/20210323212351_add_phone_and_email_to_address.rb
@@ -1,6 +1,0 @@
-class AddPhoneAndEmailToAddress < ActiveRecord::Migration[5.2]
-  def change
-    add_column :addresses, :phone, :string, default: '-', null: false
-    add_column :addresses, :email, :string, default: '-'
-  end
-end

--- a/db/migrate/20210323212351_add_phone_and_email_to_address.rb
+++ b/db/migrate/20210323212351_add_phone_and_email_to_address.rb
@@ -1,0 +1,6 @@
+class AddPhoneAndEmailToAddress < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :phone, :string, default: '-', null: false
+    add_column :addresses, :email, :string, default: '-'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_08_184243) do
+ActiveRecord::Schema.define(version: 2021_03_23_212351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define(version: 2020_06_08_184243) do
     t.bigint "city_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "phone", default: "-", null: false
+    t.string "email", default: "-"
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
     t.index ["city_id"], name: "index_addresses_on_city_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_23_212351) do
+ActiveRecord::Schema.define(version: 2020_06_08_184243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,8 +39,6 @@ ActiveRecord::Schema.define(version: 2021_03_23_212351) do
     t.bigint "city_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "phone", default: "-", null: false
-    t.string "email", default: "-"
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
     t.index ["city_id"], name: "index_addresses_on_city_id"
   end

--- a/spec/controllers/administrator/biddings/force_reviews_controller_spec.rb
+++ b/spec/controllers/administrator/biddings/force_reviews_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Administrator::Biddings::ForceReviewsController, type: :controlle
       end
 
       it { expect(controller.bidding.id).to eq bidding.id }
+      it { expect(controller.bidding.under_review?).to be_truthy }
     end
 
     describe 'response' do

--- a/spec/controllers/administrator/biddings/force_reviews_controller_spec.rb
+++ b/spec/controllers/administrator/biddings/force_reviews_controller_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Administrator::Biddings::ForceReviewsController, type: :controlle
       end
 
       it { expect(controller.bidding.id).to eq bidding.id }
-      it { expect(controller.bidding.under_review?).to be_truthy }
     end
 
     describe 'response' do

--- a/spec/controllers/administrator/biddings/reviews_controller_spec.rb
+++ b/spec/controllers/administrator/biddings/reviews_controller_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Administrator::Biddings::ReviewsController, type: :controller do
       end
 
       it { expect(controller.bidding.id).to eq bidding.id }
-      it { expect(controller.bidding.under_review?).to be_truthy }
     end
 
     describe 'response' do

--- a/spec/controllers/administrator/biddings/reviews_controller_spec.rb
+++ b/spec/controllers/administrator/biddings/reviews_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Administrator::Biddings::ReviewsController, type: :controller do
       end
 
       it { expect(controller.bidding.id).to eq bidding.id }
+      it { expect(controller.bidding.under_review?).to be_truthy }
     end
 
     describe 'response' do

--- a/spec/controllers/administrator/biddings_controller_spec.rb
+++ b/spec/controllers/administrator/biddings_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Administrator::BiddingsController, type: :controller do
 
       describe 'JSON' do
         let(:json) { JSON.parse(response.body) }
-        let(:expected_json) { biddings.map { |bidding| format_json(serializer, bidding) } }
+        let(:expected_json) { biddings.map { |bidding| format_json(serializer, bidding, scope: user) } }
 
         it { expect(json).to match_array expected_json }
       end
@@ -83,7 +83,7 @@ RSpec.describe Administrator::BiddingsController, type: :controller do
 
      describe 'JSON' do
       let(:json) { JSON.parse(response.body) }
-      let(:expected_json) { format_json(serializer, bidding) }
+      let(:expected_json) { format_json(serializer, bidding, scope: user) }
 
       it { expect(json).to eq expected_json }
     end

--- a/spec/controllers/administrator/covenants/biddings_controller_spec.rb
+++ b/spec/controllers/administrator/covenants/biddings_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Administrator::Covenants::BiddingsController, type: :controller d
 
       describe 'JSON' do
         let(:json) { JSON.parse(response.body) }
-        let(:expected_json) { biddings.map { |bidding| format_json(serializer, bidding) } }
+        let(:expected_json) { biddings.map { |bidding| format_json(serializer, bidding, scope: user) } }
 
         it { expect(json).to match_array expected_json }
       end
@@ -82,7 +82,7 @@ RSpec.describe Administrator::Covenants::BiddingsController, type: :controller d
 
      describe 'JSON' do
       let(:json) { JSON.parse(response.body) }
-      let(:expected_json) { format_json(serializer, bidding) }
+      let(:expected_json) { format_json(serializer, bidding, scope: user) }
 
       it { expect(json).to eq expected_json }
     end

--- a/spec/models/abilities/admin/reviewer_ability_spec.rb
+++ b/spec/models/abilities/admin/reviewer_ability_spec.rb
@@ -39,13 +39,9 @@ RSpec.describe Abilities::Admin::ReviewerAbility, type: :model do
   describe '.as_json' do
     let(:expected) do
       {
-        manage: [
-          "Covenant", "Group", "Cooperative", "Item", "GroupItem",
-          "Contract", "Bidding", "Proposal", "Lot", "LotProposal", "Provider",
-          "Supplier", "Unit", "User", "Notification", "Report"
-        ],
+        manage: %w[Covenant Group Cooperative Item GroupItem Contract Bidding Proposal Lot LotProposal Provider Supplier Unit User Notification Report],
         mark_as_read: ["Notification"],
-        read: ["Admin"],
+        read: %w[Bidding Admin],
         profile: ["Admin"],
         update: ["Admin"]
       }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Address, type: :model do
       it { is_expected.to validate_presence_of :neighborhood }
       it { is_expected.to validate_presence_of :cep }
       it { is_expected.to validate_presence_of :reference_point }
+      it { is_expected.to validate_presence_of :phone }
 
       it { is_expected.to validate_zip_code_for :cep }
       it { is_expected.to validate_latitude_for :latitude }

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Address, type: :model do
       it { is_expected.to validate_presence_of :neighborhood }
       it { is_expected.to validate_presence_of :cep }
       it { is_expected.to validate_presence_of :reference_point }
-      it { is_expected.to validate_presence_of :phone }
 
       it { is_expected.to validate_zip_code_for :cep }
       it { is_expected.to validate_latitude_for :latitude }

--- a/spec/serializers/address_serializer_spec.rb
+++ b/spec/serializers/address_serializer_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe AddressSerializer, type: :serializer do
     it { is_expected.to include 'cep' => object.cep }
     it { is_expected.to include 'complement' => object.complement }
     it { is_expected.to include 'reference_point' => object.reference_point }
-    it { is_expected.to include 'phone' => object.phone }
-    it { is_expected.to include 'email' => object.email }
   end
 
   describe 'associations' do

--- a/spec/serializers/address_serializer_spec.rb
+++ b/spec/serializers/address_serializer_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe AddressSerializer, type: :serializer do
     it { is_expected.to include 'cep' => object.cep }
     it { is_expected.to include 'complement' => object.complement }
     it { is_expected.to include 'reference_point' => object.reference_point }
+    it { is_expected.to include 'phone' => object.phone }
+    it { is_expected.to include 'email' => object.email }
   end
 
   describe 'associations' do

--- a/spec/services/biddings_service/finish_spec.rb
+++ b/spec/services/biddings_service/finish_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe BiddingsService::Finish, type: :service do
         to receive(:call).with(bidding).and_return(true)
       allow(Notifications::Proposals::Suppliers::All).
         to receive(:call).with(proposals: bidding.proposals).and_return(true)
-      allow(BiddingsService::Clone).
-        to receive(:call!).with(bidding: bidding).and_return(true)
     end
 
     subject { described_class.call(params) }
@@ -72,41 +70,6 @@ RSpec.describe BiddingsService::Finish, type: :service do
         it do
           expect(Notifications::Proposals::Suppliers::All).
             to have_received(:call).with(proposals: bidding.proposals)
-        end
-        it { expect(worker.jobs.size).to eq(1) }
-      end
-
-      context 'and bidding havent proposals' do
-        before do
-          bidding.proposals.map(&:draft!)
-          subject
-          bidding.reload
-        end
-
-        it { expect(bidding.desert?).to be_truthy }
-        it do
-          expect(RecalculateQuantityService).
-            to have_received(:call!).with(covenant: bidding.covenant)
-        end
-        it do
-          expect(Blockchain::Bidding::Update).
-            to have_received(:call).with(bidding)
-        end
-        it do
-          expect(BiddingsService::Clone).
-            to have_received(:call!).with(bidding: bidding)
-        end
-        it do
-          expect(ContractsService::Create::Strategy::Finnished).
-            not_to have_received(:call!).with(params)
-        end
-        it do
-          expect(Notifications::Biddings::Finished).
-            not_to have_received(:call).with(bidding)
-        end
-        it do
-          expect(Notifications::Proposals::Suppliers::All).
-            not_to have_received(:call).with(proposals: bidding.proposals)
         end
         it { expect(worker.jobs.size).to eq(1) }
       end
@@ -301,33 +264,6 @@ RSpec.describe BiddingsService::Finish, type: :service do
         end
 
         it { expect(bidding.finnished?).to be_falsey }
-        it do
-          expect(Notifications::Biddings::Finished).
-            not_to have_received(:call).with(bidding)
-        end
-        it do
-          expect(Notifications::Proposals::Suppliers::All).
-            not_to have_received(:call).with(proposals: bidding.proposals)
-        end
-        it { expect(worker.jobs.size).to eq(0) }
-      end
-
-      context 'and bidding havent proposals and clone has errors' do
-        before do
-          allow(BiddingsService::Clone).
-            to receive(:call!).with(bidding: bidding).
-            and_raise(ActiveRecord::RecordInvalid)
-
-          bidding.proposals.map(&:draft!)
-          subject
-          bidding.reload
-        end
-
-        it { expect(bidding.desert?).to be_falsey }
-        it do
-          expect(ContractsService::Create::Strategy::Finnished).
-            not_to have_received(:call!).with(params)
-        end
         it do
           expect(Notifications::Biddings::Finished).
             not_to have_received(:call).with(bidding)

--- a/spec/services/biddings_service/review_spec.rb
+++ b/spec/services/biddings_service/review_spec.rb
@@ -10,24 +10,11 @@ RSpec.describe BiddingsService::Review, type: :service do
   end
 
   describe 'call' do
+    let(:api_response) { double('api_response', success?: true) }
+    let(:worker) { Bidding::Minute::PdfGenerateWorker }
+
     before { Proposal.skip_callback(:commit, :after, :update_price_total) }
     after { Proposal.set_callback(:commit, :after, :update_price_total) }
-
-    context 'always' do
-      let!(:bidding) { create(:bidding, kind: :lot) }
-      let(:api_response) { double('api_response', success?: true) }
-
-      before do
-        allow(service).to receive(:common_review!) { true }
-        allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
-        allow(Notifications::Biddings::UnderReview).to receive(:call).with(bidding).and_call_original
-
-        service.call
-      end
-
-      it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
-      it { expect(Notifications::Biddings::UnderReview).to have_received(:call).with(bidding) }
-    end
 
     context 'when not global' do
       let!(:bidding) { create(:bidding, kind: :lot) }
@@ -89,27 +76,56 @@ RSpec.describe BiddingsService::Review, type: :service do
         end
 
         context "when updated" do
-          before { service.call }
+          context 'and all lots are desert' do
+            before do
+              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
+              allow(BiddingsService::Clone).to receive(:call!).with(bidding: bidding).and_return(true)
 
-          it { expect(lot_1.reload).to be_triage }
-          it { expect(lot_2.reload).to be_triage }
-          it { expect(lot_3.reload).to be_desert }
-          it { expect(lot_4.reload).to be_desert }
+              [proposal_a_lot_1, proposal_b_lot_1, proposal_c_lot_1].map(&:destroy!)
+              [proposal_a_lot_2, proposal_b_lot_2, proposal_c_lot_2].map(&:destroy!)
+              service.call
+            end
 
-          it { expect(proposal_abandoned_lot_1.reload).to be_abandoned }
-          it { expect(proposal_draft_lot_2.reload).to be_draft }
-          it { expect(proposal_abandoned_lot_4.reload).to be_abandoned }
-          it { expect(proposal_draft_lot_4.reload).to be_draft }
+            it { expect(lot_1.reload).to be_desert }
+            it { expect(lot_2.reload).to be_desert }
+            it { expect(lot_3.reload).to be_desert }
+            it { expect(lot_4.reload).to be_desert }
+            it { expect(bidding.reload).to be_desert }
+            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
+            it { expect(BiddingsService::Clone).to have_received(:call!).with(bidding: bidding) }
+            it { expect(worker.jobs.size).to eq(1) }
+          end
 
-          it { expect(proposal_a_lot_1.reload).to be_triage }
-          it { expect(proposal_b_lot_1.reload).to be_sent }
-          it { expect(proposal_c_lot_1.reload).to be_sent }
+          context 'and all lot are not desert' do
+            before do
+              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
+              allow(Notifications::Biddings::UnderReview).to receive(:call).with(bidding).and_call_original
 
-          it { expect(proposal_a_lot_2.reload).to be_triage }
-          it { expect(proposal_b_lot_2.reload).to be_sent }
-          it { expect(proposal_c_lot_2.reload).to be_sent }
+              service.call
+            end
 
-          it { expect(bidding.reload).to be_under_review }
+            it { expect(lot_1.reload).to be_triage }
+            it { expect(lot_2.reload).to be_triage }
+            it { expect(lot_3.reload).to be_desert }
+            it { expect(lot_4.reload).to be_desert }
+
+            it { expect(proposal_abandoned_lot_1.reload).to be_abandoned }
+            it { expect(proposal_draft_lot_2.reload).to be_draft }
+            it { expect(proposal_abandoned_lot_4.reload).to be_abandoned }
+            it { expect(proposal_draft_lot_4.reload).to be_draft }
+
+            it { expect(proposal_a_lot_1.reload).to be_triage }
+            it { expect(proposal_b_lot_1.reload).to be_sent }
+            it { expect(proposal_c_lot_1.reload).to be_sent }
+
+            it { expect(proposal_a_lot_2.reload).to be_triage }
+            it { expect(proposal_b_lot_2.reload).to be_sent }
+            it { expect(proposal_c_lot_2.reload).to be_sent }
+
+            it { expect(bidding.reload).to be_under_review }
+            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
+            it { expect(Notifications::Biddings::UnderReview).to have_received(:call).with(bidding) }
+          end
         end
 
         context 'when not updated' do
@@ -177,20 +193,32 @@ RSpec.describe BiddingsService::Review, type: :service do
         context "when updated" do
           context 'when only draft or abandoned proposals' do
             before do
+              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
+              allow(BiddingsService::Clone).to receive(:call!).with(bidding: bidding).and_return(true)
+
               [proposal, proposal_2, proposal_3].map(&:destroy!)
               service.call
             end
 
-            it { expect(lot).not_to be_triage }
+            it { expect(lot).to be_desert }
 
             it { expect(proposal_abandoned.reload).to be_abandoned }
             it { expect(proposal_draft.reload).to be_draft }
 
-            it { expect(bidding.reload).to be_under_review }
+            it { expect(bidding.reload).to be_desert }
+
+            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
+            it { expect(BiddingsService::Clone).to have_received(:call!).with(bidding: bidding) }
+            it { expect(worker.jobs.size).to eq(1) }
           end
 
           context 'when not only draft or abandoned proposals' do
-            before { service.call }
+            before do
+              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
+              allow(Notifications::Biddings::UnderReview).to receive(:call).with(bidding).and_call_original
+
+              service.call
+            end
 
             it { expect(lot).to be_triage }
 
@@ -199,6 +227,9 @@ RSpec.describe BiddingsService::Review, type: :service do
             it { expect(proposal_3.reload).to be_sent }
 
             it { expect(bidding.reload).to be_under_review }
+
+            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
+            it { expect(Notifications::Biddings::UnderReview).to have_received(:call).with(bidding) }
           end
         end
 
@@ -226,6 +257,7 @@ RSpec.describe BiddingsService::Review, type: :service do
         end
 
         it { expect(lot).to be_desert }
+        it { expect(bidding).to be_desert }
       end
     end
   end

--- a/spec/services/biddings_service/review_spec.rb
+++ b/spec/services/biddings_service/review_spec.rb
@@ -10,11 +10,24 @@ RSpec.describe BiddingsService::Review, type: :service do
   end
 
   describe 'call' do
-    let(:api_response) { double('api_response', success?: true) }
-    let(:worker) { Bidding::Minute::PdfGenerateWorker }
-
     before { Proposal.skip_callback(:commit, :after, :update_price_total) }
     after { Proposal.set_callback(:commit, :after, :update_price_total) }
+
+    context 'always' do
+      let!(:bidding) { create(:bidding, kind: :lot) }
+      let(:api_response) { double('api_response', success?: true) }
+
+      before do
+        allow(service).to receive(:common_review!) { true }
+        allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
+        allow(Notifications::Biddings::UnderReview).to receive(:call).with(bidding).and_call_original
+
+        service.call
+      end
+
+      it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
+      it { expect(Notifications::Biddings::UnderReview).to have_received(:call).with(bidding) }
+    end
 
     context 'when not global' do
       let!(:bidding) { create(:bidding, kind: :lot) }
@@ -76,56 +89,27 @@ RSpec.describe BiddingsService::Review, type: :service do
         end
 
         context "when updated" do
-          context 'and all lots are desert' do
-            before do
-              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
-              allow(BiddingsService::Clone).to receive(:call!).with(bidding: bidding).and_return(true)
+          before { service.call }
 
-              [proposal_a_lot_1, proposal_b_lot_1, proposal_c_lot_1].map(&:destroy!)
-              [proposal_a_lot_2, proposal_b_lot_2, proposal_c_lot_2].map(&:destroy!)
-              service.call
-            end
+          it { expect(lot_1.reload).to be_triage }
+          it { expect(lot_2.reload).to be_triage }
+          it { expect(lot_3.reload).to be_desert }
+          it { expect(lot_4.reload).to be_desert }
 
-            it { expect(lot_1.reload).to be_desert }
-            it { expect(lot_2.reload).to be_desert }
-            it { expect(lot_3.reload).to be_desert }
-            it { expect(lot_4.reload).to be_desert }
-            it { expect(bidding.reload).to be_desert }
-            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
-            it { expect(BiddingsService::Clone).to have_received(:call!).with(bidding: bidding) }
-            it { expect(worker.jobs.size).to eq(1) }
-          end
+          it { expect(proposal_abandoned_lot_1.reload).to be_abandoned }
+          it { expect(proposal_draft_lot_2.reload).to be_draft }
+          it { expect(proposal_abandoned_lot_4.reload).to be_abandoned }
+          it { expect(proposal_draft_lot_4.reload).to be_draft }
 
-          context 'and all lot are not desert' do
-            before do
-              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
-              allow(Notifications::Biddings::UnderReview).to receive(:call).with(bidding).and_call_original
+          it { expect(proposal_a_lot_1.reload).to be_triage }
+          it { expect(proposal_b_lot_1.reload).to be_sent }
+          it { expect(proposal_c_lot_1.reload).to be_sent }
 
-              service.call
-            end
+          it { expect(proposal_a_lot_2.reload).to be_triage }
+          it { expect(proposal_b_lot_2.reload).to be_sent }
+          it { expect(proposal_c_lot_2.reload).to be_sent }
 
-            it { expect(lot_1.reload).to be_triage }
-            it { expect(lot_2.reload).to be_triage }
-            it { expect(lot_3.reload).to be_desert }
-            it { expect(lot_4.reload).to be_desert }
-
-            it { expect(proposal_abandoned_lot_1.reload).to be_abandoned }
-            it { expect(proposal_draft_lot_2.reload).to be_draft }
-            it { expect(proposal_abandoned_lot_4.reload).to be_abandoned }
-            it { expect(proposal_draft_lot_4.reload).to be_draft }
-
-            it { expect(proposal_a_lot_1.reload).to be_triage }
-            it { expect(proposal_b_lot_1.reload).to be_sent }
-            it { expect(proposal_c_lot_1.reload).to be_sent }
-
-            it { expect(proposal_a_lot_2.reload).to be_triage }
-            it { expect(proposal_b_lot_2.reload).to be_sent }
-            it { expect(proposal_c_lot_2.reload).to be_sent }
-
-            it { expect(bidding.reload).to be_under_review }
-            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
-            it { expect(Notifications::Biddings::UnderReview).to have_received(:call).with(bidding) }
-          end
+          it { expect(bidding.reload).to be_under_review }
         end
 
         context 'when not updated' do
@@ -193,32 +177,20 @@ RSpec.describe BiddingsService::Review, type: :service do
         context "when updated" do
           context 'when only draft or abandoned proposals' do
             before do
-              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
-              allow(BiddingsService::Clone).to receive(:call!).with(bidding: bidding).and_return(true)
-
               [proposal, proposal_2, proposal_3].map(&:destroy!)
               service.call
             end
 
-            it { expect(lot).to be_desert }
+            it { expect(lot).not_to be_triage }
 
             it { expect(proposal_abandoned.reload).to be_abandoned }
             it { expect(proposal_draft.reload).to be_draft }
 
-            it { expect(bidding.reload).to be_desert }
-
-            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
-            it { expect(BiddingsService::Clone).to have_received(:call!).with(bidding: bidding) }
-            it { expect(worker.jobs.size).to eq(1) }
+            it { expect(bidding.reload).to be_under_review }
           end
 
           context 'when not only draft or abandoned proposals' do
-            before do
-              allow(Blockchain::Bidding::Update).to receive(:call).with(bidding) { api_response }
-              allow(Notifications::Biddings::UnderReview).to receive(:call).with(bidding).and_call_original
-
-              service.call
-            end
+            before { service.call }
 
             it { expect(lot).to be_triage }
 
@@ -227,9 +199,6 @@ RSpec.describe BiddingsService::Review, type: :service do
             it { expect(proposal_3.reload).to be_sent }
 
             it { expect(bidding.reload).to be_under_review }
-
-            it { expect(Blockchain::Bidding::Update).to have_received(:call).with(bidding) }
-            it { expect(Notifications::Biddings::UnderReview).to have_received(:call).with(bidding) }
           end
         end
 
@@ -257,7 +226,6 @@ RSpec.describe BiddingsService::Review, type: :service do
         end
 
         it { expect(lot).to be_desert }
-        it { expect(bidding).to be_desert }
       end
     end
   end

--- a/spec/services/biddings_service/under_review_spec.rb
+++ b/spec/services/biddings_service/under_review_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).not_to have_received(:call).with(bidding: bidding) }
+      it { expect(bidding.reload.under_review?).to be_falsy }
     end
 
     context 'when proposals not draw' do
@@ -42,6 +43,7 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).to have_received(:call).with(bidding: bidding) }
+      it { expect(bidding.reload.under_review?).to be_truthy }
     end
   end
 
@@ -66,6 +68,7 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).not_to have_received(:call).with(bidding: bidding) }
+      it { expect(bidding.reload.under_review?).to be_falsy }
     end
 
     context 'when proposals not draw' do
@@ -76,6 +79,7 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).to have_received(:call).with(bidding: bidding) }
+      it { expect(bidding.reload.under_review?).to be_truthy }
     end
   end
 end

--- a/spec/services/biddings_service/under_review_spec.rb
+++ b/spec/services/biddings_service/under_review_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).not_to have_received(:call).with(bidding: bidding) }
-      it { expect(bidding.reload.under_review?).to be_falsy }
     end
 
     context 'when proposals not draw' do
@@ -43,7 +42,6 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).to have_received(:call).with(bidding: bidding) }
-      it { expect(bidding.reload.under_review?).to be_truthy }
     end
   end
 
@@ -68,7 +66,6 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).not_to have_received(:call).with(bidding: bidding) }
-      it { expect(bidding.reload.under_review?).to be_falsy }
     end
 
     context 'when proposals not draw' do
@@ -79,7 +76,6 @@ RSpec.describe BiddingsService::UnderReview, type: :service do
       end
 
       it { expect(BiddingsService::Review).to have_received(:call).with(bidding: bidding) }
-      it { expect(bidding.reload.under_review?).to be_truthy }
     end
   end
 end


### PR DESCRIPTION
- [Item 13] O botão “fracassar licitação” que fica disponível somente para o módulo do revisor terá que ser retirado
- [Item 19a] Inserir botão para preencher o endereço da sede da entidade automaticamente
- [Item 10] Remover botão de cancelar licitação quando for deserta e possibilitar gerar ata automaticamente
- Incluir campos phone e email no backend